### PR TITLE
Clean trailing whitespace for ruby files, and fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ file.
 
 In order to install the config, please make sure you have `ag`, a.k.a the silver searcher,
 installed on your machine.
+
+This configuration require vim 7.4 or later.

--- a/vimrc
+++ b/vimrc
@@ -1,5 +1,4 @@
 let mapleader = " "
-let maplocalleader = ";"
 
 syntax on
 

--- a/vimrc.config
+++ b/vimrc.config
@@ -39,6 +39,12 @@ let g:NERDTreeWinSize = 20
 " Change working directory if you change root directories
 let g:NERDTreeChDirMode=2
 
+"========== Folding ==========
+set foldmethod=indent   "fold based on indent
+set foldnestmax=10      "deepest fold is 10 levels
+set nofoldenable        "dont fold by default
+set foldlevel=1         "this is just what i use
+
 "========== vim-fugitivie ==========
 map <leader>g   :Gblame<CR>
 " clean up unused fugitive buffers
@@ -126,7 +132,7 @@ if exists("+showtabline")
     highlight link TabNum Special
 endif
 
-" Quicker window movement
+"========== Quicker window movement ==========
 nnoremap <C-j> <C-w>j
 nnoremap <C-k> <C-w>k
 nnoremap <C-h> <C-w>h

--- a/vimrc.ruby.config
+++ b/vimrc.ruby.config
@@ -9,3 +9,18 @@ map <Leader>a :call RunAllSpecs()<CR>
 
 let g:rspec_runner = "os_x_iterm"
 let g:rspec_command = "!bundle exec rspec {spec}"
+
+"========= remove trailing whitespace ==========
+function! <SID>StripTrailingWhitespaces()
+  " Preparation: save last search, and cursor position.
+  let _s=@/
+  let l = line(".")
+  let c = col(".")
+  " Do the business:
+  %s/\s\+$//e
+  " Clean up: restore previous search history, and cursor position
+  let @/=_s
+  call cursor(l, c)
+endfunction
+
+autocmd InsertLeave *.rb :call <SID>StripTrailingWhitespaces()


### PR DESCRIPTION
- Added function for clearing whitespace, currently only being
  used for ruby files.
- Added some sane folding defaults
